### PR TITLE
moved TOC after acknowledgements and dedication sections

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -30,9 +30,9 @@
 % \input{preface}
 % This is because FoGS formatting pedandtry is especially accute when
 % it comes to tables of contents
-\allcontents
 \input{acknowledgements}
 \input{dedication}
+\allcontents
 \cleardoublepage
 \mainbody
 


### PR DESCRIPTION
On page 30 of the UIdaho 2015-2016 Handbook the example shows the table of contents (TOC) occurring after the acknowledgments and dedication sections. This PR fixed the order in thesis.tex to reflect this. 
